### PR TITLE
Fix Flaky Setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,6 @@ from __future__ import print_function
 from setuptools import setup, Command
 import os
 
-import weighted
-
 
 description = 'Weighted quantiles, including weighted median, based on numpy'
 long_description = description
@@ -28,7 +26,7 @@ class PyTest(Command):
 
 setup(
     name='wquantiles',
-    version=weighted.__version__,
+    version='0.4',
     url='http://github.com/nudomarinero/wquantiles/',
     license='MIT License',
     author='Jose Sabater',


### PR DESCRIPTION
Hi,
I use your wquantiles package quite a bit, it's really handy (thanks!).
I regularly run into a problem with setup.py though.

Setup.py imports the weighted module, which causes the installation to fail if numpy hasn't been separately installed first. This means that you've got to install numpy first and then install wquantiles, which you shouldn't need to do (it should be possible to install them both at the same time).

The best way to deal with it would be to remove the import statement from setup.py and specify the version number manually.

Kind regards,
Mike
