### PR TITLE
replace recalculation of sum by last element of cumsum array

### DIFF
--- a/wquantiles.py
+++ b/wquantiles.py
@@ -49,7 +49,7 @@ def quantile_1D(data, weights, quantile):
     Sn = np.cumsum(sorted_weights)
     # TODO: Check that the weights do not sum zero
     #assert Sn != 0, "The sum of the weights must not be zero"
-    Pn = (Sn-0.5*sorted_weights)/np.sum(sorted_weights)
+    Pn = (Sn-0.5*sorted_weights)/Sn[-1]
     # Get the value of the weighted median
     return np.interp(quantile, Pn, sorted_data)
 


### PR DESCRIPTION
You can get rid of recalculating the sum of `sorted_weights` -- it corresponds to the last element of the previous `cumsum` calculation, the result of which is held by `Sn`